### PR TITLE
[WIP] Add option to use Pytorch

### DIFF
--- a/workflows/common/python/model_runner.py
+++ b/workflows/common/python/model_runner.py
@@ -30,26 +30,35 @@ def import_pkg(framework, model_name):
     # The model_name is the short form of the Benchmark: e.g., 'nt3'
     # The module_name is the name of the Python module:  e.g., 'nt3_baseline_keras2'
     print("model_name: ", model_name)
-    if framework != 'keras':
-        raise ValueError("Invalid framework: '{}'".format(framework))
     module_name = os.getenv("MODEL_PYTHON_SCRIPT")
-    if module_name == None or module_name == "":
-        module_name = "{}_baseline_keras2".format(model_name)
-    print ("module_name:", module_name)
-    pkg = importlib.import_module(module_name)
+    if framework == 'keras':
+        if module_name == None or module_name == "":
+            module_name = "{}_baseline_keras2".format(model_name)
+            print ("module_name:", module_name)
+        pkg = importlib.import_module(module_name)
 
-    from keras import backend as K
-    if K.backend() == 'tensorflow' and 'NUM_INTER_THREADS' in os.environ:
-        import tensorflow as tf
-        inter_threads = int(os.environ['NUM_INTER_THREADS'])
-        intra_threads = int(os.environ['NUM_INTRA_THREADS'])
-        print("Configuring tensorflow with {} inter threads and {} intra threads"
-              .format(inter_threads, intra_threads))
-        cfg = tf.ConfigProto(inter_op_parallelism_threads=inter_threads,
-                             intra_op_parallelism_threads=intra_threads)
-        sess = tf.Session(graph=tf.get_default_graph(), config=cfg)
-        K.set_session(sess)
+        from keras import backend as K
+        if K.backend() == 'tensorflow' and 'NUM_INTER_THREADS' in os.environ:
+            import tensorflow as tf
+            inter_threads = int(os.environ['NUM_INTER_THREADS'])
+            intra_threads = int(os.environ['NUM_INTRA_THREADS'])
+            print("Configuring tensorflow with {} inter threads and {} intra threads"
+                  .format(inter_threads, intra_threads))
+            cfg = tf.ConfigProto(inter_op_parallelism_threads=inter_threads,
+                                 intra_op_parallelism_threads=intra_threads)
+            sess = tf.Session(graph=tf.get_default_graph(), config=cfg)
+            K.set_session(sess)
+    elif framework == 'pytorch':
+        import torch
+        if module_name == None or module_name == "":
+            module_name = "{}_baseline_pytorch".format(model_name)
+            print ("module_name:", module_name)
+        pkg = importlib.import_module(module_name)
+    else:
+        raise ValueError("Framework must either be `keras` or `pytorch`, got {}!".format(framework))
+
     return pkg
+
 
 def log(msg):
     global logger

--- a/workflows/common/python/model_runner.py
+++ b/workflows/common/python/model_runner.py
@@ -152,7 +152,8 @@ def run(hyper_parameter_map, obj_return):
     # Run the model!
     history = pkg.run(params)
 
-    runner_utils.keras_clear_session(framework)
+    if framework == 'keras':
+        runner_utils.keras_clear_session(framework)
 
     # Default result if there is no val_loss (as in infer.py)
     result = 0


### PR DESCRIPTION
Model runner currently only supporst `keras`. We would like to use
either keras or pytorch here.

Current behavior was essentially checking the name of the framework
and importing a module with a correctly formatted name. This change
essentially does the same thing, adding a second conditional
statment in `import_pkg()`.